### PR TITLE
Update Immer & Fix Import Issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "immer": "1.8.0 - 10"
+    "immer": "^10.1.1"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,13 +1,12 @@
-import createStore from "./index"
-
+import createStore from "./index";
 
 interface State {
-  numberOfWalks: number
+  numberOfWalks: number;
   animals: {
-    name: string
-    age: number
-    isBad?: boolean
-  }[]
+    name: string;
+    age: number;
+    isBad?: boolean;
+  }[];
 }
 
 const state: State = {
@@ -15,162 +14,159 @@ const state: State = {
   animals: [
     {
       name: "Aiofe",
-      age: 6
+      age: 6,
     },
     {
       name: "Sen",
-      age: 8
-    }
-  ]
-}
+      age: 8,
+    },
+  ],
+};
 
+const store = createStore(state);
 
-const store = createStore(state)
+test("Allows access to state", () => {
+  const storeState = store.state;
 
+  expect(storeState.numberOfWalks).toBe(2876);
+  expect(storeState.animals.length).toBe(2);
+  expect(storeState.animals[1].name).toBe("Sen");
+});
 
-test("Allows access to state", ()=> {
-  const storeState = store.state
+test("Allow function updates", () => {
+  expect(store.state.numberOfWalks).toBe(2876);
 
-  expect(storeState.numberOfWalks).toBe(2876)
-  expect(storeState.animals.length).toBe(2)
-  expect(storeState.animals[1].name).toBe("Sen")
-})
+  store.update((s) => s.numberOfWalks++);
 
-test("Allow function updates", ()=> {
-  expect(store.state.numberOfWalks).toBe(2876)
+  expect(store.state.numberOfWalks).toBe(2877);
+});
 
-  store.update(s=> s.numberOfWalks++)
+test("Allow object updates", () => {
+  store.update({ numberOfWalks: 100 });
 
-  expect(store.state.numberOfWalks).toBe(2877)
-})
+  expect(store.state.numberOfWalks).toBe(100);
+});
 
-test("Allow object updates", ()=> {
-  store.update({numberOfWalks: 100})
+test("More Updating", () => {
+  store.update((s) => s.animals.push({ name: "Odin", age: 5 }));
 
-  expect(store.state.numberOfWalks).toBe(100)
-})
+  expect(store.state.animals.length).toBe(3);
+});
 
-test("More Updating", ()=> {
-  store.update(s=> s.animals.push({name: "Odin", age: 5}))
+describe("Sub-stores", () => {
+  test("Basic usage", () => {
+    const odinStore = store.storeFor((s) => s.animals[2]);
 
-  expect(store.state.animals.length).toBe(3)
-})
+    expect(odinStore.state.name).toBe("Odin");
+    expect(odinStore.state.isBad).toBe(undefined);
 
-describe("Sub-stores", ()=> {
-  test("Basic usage", ()=> {
-    const odinStore = store.storeFor(s=> s.animals[2])
-  
-    expect(odinStore.state.name).toBe("Odin")
-    expect(odinStore.state.isBad).toBe(undefined)
-  
-    odinStore.update({isBad: true})
-    expect(odinStore.state.isBad).toBe(true)
-  })
+    odinStore.update({ isBad: true });
+    expect(odinStore.state.isBad).toBe(true);
+  });
 
-  test("a sub-sub-store", ()=> {
-    const animalsStore = store.storeFor(s=> s.animals)
-    const aiofeStore   = animalsStore.storeFor(s=> s[0])
+  test("a sub-sub-store", () => {
+    const animalsStore = store.storeFor((s) => s.animals);
+    const aiofeStore = animalsStore.storeFor((s) => s[0]);
 
-    expect(aiofeStore.state.name).toBe("Aiofe")
-  })
-})
+    expect(aiofeStore.state.name).toBe("Aiofe");
+  });
+});
 
-describe("A store for a single property", ()=> {
-  const walksStore = store.storeFor(s=> s.numberOfWalks)
+describe("A store for a single property", () => {
+  const walksStore = store.storeFor((s) => s.numberOfWalks);
 
-  test("Can get a single property's state", ()=> {
-    expect(walksStore.state).toBe(100)
-  })
+  test("Can get a single property's state", () => {
+    expect(walksStore.state).toBe(100);
+  });
 
-  test("Can't update a store with a single property", ()=> {
-    walksStore.update(n=> n += 50)
+  test("Can't update a store with a single property", () => {
+    walksStore.update((n) => (n += 50));
 
-    expect(walksStore.state).not.toBe(150)
-  })
-})
+    expect(walksStore.state).not.toBe(150);
+  });
+});
 
+describe("Immutability", () => {
+  const senStore = store.storeFor((s) => s.animals[1]);
 
-describe("Immutability", ()=> {
-  const senStore = store.storeFor(s=> s.animals[1])
+  test("Unmodified objects stay the same", () => {
+    const before = senStore.state;
+    const rootBefore = store.state.animals[1];
+    expect(before).toBe(rootBefore);
 
-  test("Unmodified objects stay the same", ()=> {
-    const before     = senStore.state
-    const rootBefore = store.state.animals[1]
-    expect(before).toBe(rootBefore)
+    expect(before).toBe(senStore.state);
+    expect(rootBefore).toBe(store.state.animals[1]);
+  });
 
-    expect(before).toBe(senStore.state)
-    expect(rootBefore).toBe(store.state.animals[1])
-  })
+  test("Modified objects are different objects", () => {
+    const before = senStore.state;
+    const rootBefore = store.state.animals[1];
+    expect(before).toBe(rootBefore);
 
-  test("Modified objects are different objects", ()=> {
-    const before     = senStore.state
-    const rootBefore = store.state.animals[1]
-    expect(before).toBe(rootBefore)
+    senStore.update({ isBad: false });
 
-    senStore.update({isBad: false})
+    expect(before).not.toBe(senStore.state);
+    expect(rootBefore).not.toBe(store.state.animals[1]);
+  });
+});
 
-    expect(before).not.toBe(senStore.state)
-    expect(rootBefore).not.toBe(store.state.animals[1])
-  })
-})
+test("Updaters", () => {
+  const aiofeUpdater = store.updaterFor((s) => s.animals[0]);
 
-test("Updaters", ()=> {
-  const aiofeUpdater = store.updaterFor(s=> s.animals[0])
+  expect(store.state.animals[0].isBad).toBe(undefined);
 
-  expect(store.state.animals[0].isBad).toBe(undefined)
+  aiofeUpdater((aiofe) => (aiofe.isBad = false));
+  expect(store.state.animals[0].isBad).toBe(false);
+});
 
-  aiofeUpdater(aiofe=> aiofe.isBad = false)
-  expect(store.state.animals[0].isBad).toBe(false)
-})
+describe("Subscriptions", () => {
+  test("subscriptions are called", () => {
+    let callbackCalled = false;
+    store.subscribe(() => (callbackCalled = true));
+    expect(callbackCalled).toBe(false);
 
-describe("Subscriptions", ()=> {
-  test("subscriptions are called", ()=> {
-    let callbackCalled = false
-    store.subscribe(()=> callbackCalled = true)
-    expect(callbackCalled).toBe(false)
+    store.update((s) => s.numberOfWalks++);
+    expect(callbackCalled).toBe(true);
+  });
 
-    store.update(s=> s.numberOfWalks++)
-    expect(callbackCalled).toBe(true)
-  })
+  test("subscriptions aren't called if data isn't changed", () => {
+    let callbackCalled = false;
+    store.subscribe(() => (callbackCalled = true));
+    expect(callbackCalled).toBe(false);
 
-  test("subscriptions aren't called if data isn't changed", ()=> {
-    let callbackCalled = false
-    store.subscribe(()=> callbackCalled = true)
-    expect(callbackCalled).toBe(false)
+    const numberOfWalks = store.state.numberOfWalks;
+    store.update({ numberOfWalks });
+    expect(callbackCalled).toBe(false);
+  });
 
-    const numberOfWalks = store.state.numberOfWalks
-    store.update({ numberOfWalks })
-    expect(callbackCalled).toBe(false)
-  })
+  test("updating with a sub-store trigger subscribed callbacks", () => {
+    const senStore = store.storeFor((s) => s.animals[1]);
+    let callbackCalled = false;
+    store.subscribe(() => (callbackCalled = true));
+    senStore.update((s) => s.age++);
 
-  test("updating with a sub-store trigger subscribed callbacks", ()=> {
-    const senStore = store.storeFor(s=> s.animals[1])
-    let callbackCalled = false
-    store.subscribe(()=> callbackCalled = true)
-    senStore.update(s=> s.age++)
+    expect(callbackCalled).toBe(true);
+  });
 
-    expect(callbackCalled).toBe(true)
-  })
+  test("subscriptions can be cancelled", () => {
+    let count = 0;
+    const cancelSubscription = store.subscribe(() => count++);
 
-  test('subscriptions can be cancelled', ()=> {
-    let count = 0
-    const cancelSubscription = store.subscribe(()=> count++)
+    store.update((s) => s.numberOfWalks++);
+    store.update((s) => s.numberOfWalks++);
+    expect(count).toBe(2);
 
-    store.update(s=> s.numberOfWalks++)
-    store.update(s=> s.numberOfWalks++)
-    expect(count).toBe(2)
+    cancelSubscription();
+    store.update((s) => s.numberOfWalks++);
+    expect(count).toBe(2);
+  });
 
-    cancelSubscription()
-    store.update(s=> s.numberOfWalks++)
-    expect(count).toBe(2)
-  })
+  test("sub-stores can be subscribed to", () => {
+    const senStore = store.storeFor((s) => s.animals[1]);
+    let callbackCalled = false;
+    senStore.subscribe(() => (callbackCalled = true));
+    senStore.update((s) => s.age++);
 
-  test("sub-stores can be subscribed to", ()=> {
-    const senStore = store.storeFor(s=> s.animals[1])
-    let callbackCalled = false
-    senStore.subscribe(()=> callbackCalled = true)
-    senStore.update(s=> s.age++)
-
-    expect(callbackCalled).toBe(true)
-  })
-})
+    expect(callbackCalled).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,47 @@
-import produce from "immer"
+import { produce } from "immer";
 
 export class PureStore<S, T> {
-  callbacks = []
-  rootState: T
-  getter: (s: S)=>T
-  root: any
-  parent: any
+  callbacks = [];
+  rootState: T;
+  getter: (s: S) => T;
+  root: any;
+  parent: any;
 
-  constructor(parent, getter: (s: S)=>T, rootState?: T) {
-    this.parent = parent
-    this.root = (parent && parent.root) || this
-    if (!parent) this.rootState = rootState
-    this.getter = (s: S)=> getter(parent ? parent.getter(s) : s)
+  constructor(parent, getter: (s: S) => T, rootState?: T) {
+    this.parent = parent;
+    this.root = (parent && parent.root) || this;
+    if (!parent) this.rootState = rootState;
+    this.getter = (s: S) => getter(parent ? parent.getter(s) : s);
   }
 
-  getState = ()=> this.getter(this.root.rootState)
-  get state() { return this.getState() }
+  getState = () => this.getter(this.root.rootState);
+  get state() {
+    return this.getState();
+  }
 
-  update = (updater: ((e: T)=> void)|Partial<T>)=> {
-    const updaterFn = (updater instanceof Function) ?
-      updater : e=> Object.assign(e, updater)
+  update = (updater: ((e: T) => void) | Partial<T>) => {
+    const updaterFn =
+      updater instanceof Function ? updater : (e) => Object.assign(e, updater);
 
-    const oldState = this.root.rootState
+    const oldState = this.root.rootState;
 
-    this.root.rootState = produce(this.root.rootState, s=> {
-      updaterFn(this.getter(s))
-    })
+    this.root.rootState = produce(this.root.rootState, (s) => {
+      updaterFn(this.getter(s));
+    });
 
     if (this.root.rootState !== oldState) {
-      this.root.callbacks.forEach(callback=> callback())
+      this.root.callbacks.forEach((callback) => callback());
     }
-  }
+  };
 
-  storeFor   = <X>(getter: (s: T)=>X)=> new PureStore(this, getter)
-  updaterFor = <X>(getter: (s: T)=>X)=> this.storeFor(getter).update
+  storeFor = <X>(getter: (s: T) => X) => new PureStore(this, getter);
+  updaterFor = <X>(getter: (s: T) => X) => this.storeFor(getter).update;
 
-  subscribe = callback=> {
-    this.root.callbacks.push(callback)
-    return ()=> this.root.callbacks.splice(this.root.callbacks.indexOf(callback), 1)
-  }
+  subscribe = (callback) => {
+    this.root.callbacks.push(callback);
+    return () =>
+      this.root.callbacks.splice(this.root.callbacks.indexOf(callback), 1);
+  };
 }
 
-export default <S>(state: S)=> (
-  new PureStore(null, (s: S)=> s, state)
-)
+export default <S>(state: S) => new PureStore(null, (s: S) => s, state);

--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -1,65 +1,68 @@
-import * as React from 'react'
-import * as ReactDOM from 'react-dom'
-import { act } from 'react-dom/test-utils'
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
 
-import createStore from "./react"
+import createStore from "./react";
 
-
-
-const counterStore = createStore({ count: 0 })
-const Counter = ()=> {
-  const [state, update] = counterStore.usePureStore()
+const counterStore = createStore({ count: 0 });
+const Counter = () => {
+  const [state, update] = counterStore.usePureStore();
 
   return (
     <div>
       <span>{state.count}</span>
-      <button onClick={()=> update(s=> s.count++)}>+</button>
-      <button onClick={()=> update(s=> s.count--)}>-</button>
+      <button onClick={() => update((s) => s.count++)}>+</button>
+      <button onClick={() => update((s) => s.count--)}>-</button>
     </div>
-  )
-}
+  );
+};
 
+let container: HTMLDivElement | null = null;
 
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
 
-let container: HTMLDivElement
+afterEach(() => {
+  if (!container) {
+    return;
+  }
+  document.body.removeChild(container);
+  container = null;
+});
 
-beforeEach(()=> {
-  container = document.createElement('div')
-  document.body.appendChild(container)
-})
+describe("Using a component with usePureStore()", () => {
+  test("Renders as expected", () => {
+    act(() => {
+      ReactDOM.render(<Counter />, container);
+    });
 
-afterEach(()=> {
-  document.body.removeChild(container)
-  container = null
-})
+    const count = container!.querySelector("span")!.textContent;
+    expect(count).toBe("0");
+  });
 
-describe("Using a component with usePureStore()", ()=> {
-  test("Renders as expected", ()=> {
-    act(()=> { ReactDOM.render(<Counter />, container) })
-  
-    const count = container.querySelector("span").textContent
-    expect(count).toBe("0")
-  })
+  test("Works with interaction and updates", () => {
+    act(() => {
+      ReactDOM.render(<Counter />, container);
+    });
 
-  test("Works with interaction and updates", ()=> {
-    act(()=> { ReactDOM.render(<Counter />, container) })
+    const [inc, dec] = container!.querySelectorAll(
+      "button",
+    ) as unknown as HTMLButtonElement[];
 
-    const [inc, dec] = container.querySelectorAll("button") as unknown as HTMLButtonElement[]
-
-    act(()=> {
-      for (let i=0; i<12; i++) {
-        inc.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    act(() => {
+      for (let i = 0; i < 12; i++) {
+        inc.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       }
 
-      dec.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      dec.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
-    const count = container.querySelector("span").textContent
-    expect(count).toBe("11")
-  })
-})
-
-
+    const count = container!.querySelector("span")!.textContent;
+    expect(count).toBe("11");
+  });
+});
 
 const store = createStore({
   lists: [
@@ -69,17 +72,17 @@ const store = createStore({
       items: [
         {
           name: "eggs",
-          purchased: false
+          purchased: false,
         },
         {
           name: "bread",
-          purchased: true
+          purchased: true,
         },
         {
           name: "eggs",
-          purchased: false
-        }
-      ]
+          purchased: false,
+        },
+      ],
     },
     {
       date: new Date(+new Date() - 86400000),
@@ -87,143 +90,153 @@ const store = createStore({
       items: [
         {
           name: "vinegar",
-          purchased: true
-        }
-      ]
-    }
-  ]
-})
-const ShoppingApp = ()=> {
-  const [state] = store.usePureStore()
+          purchased: true,
+        },
+      ],
+    },
+  ],
+});
+const ShoppingApp = () => {
+  const [state] = store.usePureStore();
 
   return (
     <div className="shopping-app">
       <h1>
         Shopping
         <small>
-          { state.lists.length } { "lists, " }
-          { state.lists.filter(d=> !d.completed).length } uncompleted
+          {state.lists.length} {"lists, "}
+          {state.lists.filter((d) => !d.completed).length} uncompleted
         </small>
       </h1>
 
       <NextDueList />
     </div>
-  )
-}
+  );
+};
 
-const NextDueList = React.memo(()=> {
-  const [state, update] = store.usePureStore(s=> s.lists.find(l=> l.completed==false))
+const NextDueList = React.memo(() => {
+  const [state, update] = store.usePureStore((s) =>
+    s.lists.find((l) => l.completed == false),
+  );
 
   // If there are no lists due:
-  if (!state) return null
+  if (!state) return null;
 
-  const {date, completed, items} = state
+  const { date, completed, items } = state;
 
   return (
     <div className="list">
       <h3>
         List for {date.toLocaleString()}
         <small>
-          { items.length } items, { items.filter(d=> !d.purchased).length } unpurchased
+          {items.length} items, {items.filter((d) => !d.purchased).length}{" "}
+          unpurchased
         </small>
       </h3>
 
       <input
         type="checkbox"
         checked={completed}
-        onChange={()=> update({ completed: !completed })}
+        onChange={() => update({ completed: !completed })}
       />
 
       <ul>
-        {
-          items.map((item, i)=>
-            <li key={i}>
-              <label>
-                { item.name }
+        {items.map((item, i) => (
+          <li key={i}>
+            <label>
+              {item.name}
 
-                <input
-                  type="checkbox"
-                  checked={completed}
-                  onChange={e=> update(s=> s.items[i].purchased = e.target.checked)}
-                />
-              </label>
-            </li>
-          )
-        }
+              <input
+                type="checkbox"
+                checked={completed}
+                onChange={(e) =>
+                  update((s) => (s!.items[i].purchased = e.target.checked))
+                }
+              />
+            </label>
+          </li>
+        ))}
       </ul>
     </div>
-  )
-})
+  );
+});
 
+describe("Using usePureStore with a getter", () => {
+  test("Renders as expected", () => {
+    act(() => {
+      ReactDOM.render(<ShoppingApp />, container);
+    });
 
-describe("Using usePureStore with a getter", ()=> {
-  test("Renders as expected", ()=> {
-    act(()=> { ReactDOM.render(<ShoppingApp />, container) })
+    const text = container!.querySelector("h1 small")!.textContent;
+    expect(text).toBe("2 lists, 1 uncompleted");
 
-    const text = container.querySelector("h1 small").textContent
-    expect(text).toBe("2 lists, 1 uncompleted")
+    const listDescription = container!.querySelector("h3 small")!.textContent;
+    expect(listDescription).toBe("3 items, 2 unpurchased");
+  });
 
-    const listDescription = container.querySelector("h3 small").textContent
-    expect(listDescription).toBe("3 items, 2 unpurchased")
-  })
+  test("Works with interaction and updates", async () => {
+    act(() => {
+      ReactDOM.render(<ShoppingApp />, container);
+    });
 
-  test("Works with interaction and updates", async ()=> {
-    act(()=> { ReactDOM.render(<ShoppingApp />, container) })
+    act(() => {
+      const eggCheckbox = container!.querySelector(".list ul input");
 
-    act(()=> {
-      const eggCheckbox = container.querySelector(".list ul input")
+      eggCheckbox!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
-      eggCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+    const listDescription = container!.querySelector("h3 small")!.textContent;
+    expect(listDescription).toBe("3 items, 1 unpurchased");
 
-    const listDescription = container.querySelector("h3 small").textContent
-    expect(listDescription).toBe("3 items, 1 unpurchased")
+    act(() => {
+      const checkbox = container!.querySelector(".list > input");
+      checkbox!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
+    const appDescription = container!.querySelector("h1 small")!.textContent;
+    expect(appDescription).toBe("2 lists, 0 uncompleted");
+  });
+});
 
-    act(()=> {
-      const checkbox = container.querySelector(".list > input")
-      checkbox.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+const renderStore = createStore({ count: 0 });
+const RenderTest = React.memo(() => {
+  const [{ count }] = renderStore.usePureStore();
 
-    const appDescription = container.querySelector("h1 small").textContent
-    expect(appDescription).toBe("2 lists, 0 uncompleted")
-  })
-})
+  return (
+    <span>
+      {count} - {Math.random()}
+    </span>
+  );
+});
 
+describe("Using a component with usePureStore()", () => {
+  test("Re-renders with new values", () => {
+    act(() => {
+      ReactDOM.render(<RenderTest />, container);
+    });
+    const value1 = container!.querySelector("span")!.textContent;
 
+    act(() => {
+      renderStore.update((s) => s.count++);
+      ReactDOM.render(<RenderTest />, container);
+    });
+    const value2 = container!.querySelector("span")!.textContent;
 
-const renderStore = createStore({ count: 0 })
-const RenderTest = React.memo(()=> {
-  const [{ count }] = renderStore.usePureStore()
+    expect(value1).not.toBe(value2);
+  });
 
-return <span>{ count } - { Math.random() }</span>
-})
+  test("Does not re-render with unchanged values", () => {
+    act(() => {
+      ReactDOM.render(<RenderTest />, container);
+    });
+    const value1 = container!.querySelector("span")!.textContent;
 
+    act(() => {
+      renderStore.update((s) => (s.count = s.count));
+      ReactDOM.render(<RenderTest />, container);
+    });
+    const value2 = container!.querySelector("span")!.textContent;
 
-describe("Using a component with usePureStore()", ()=> {
-  test("Re-renders with new values", ()=> {
-    act(()=> { ReactDOM.render(<RenderTest />, container) })
-    const value1 = container.querySelector("span").textContent
-
-    act(()=> {
-      renderStore.update(s=> s.count++)
-      ReactDOM.render(<RenderTest />, container)
-    })
-    const value2 = container.querySelector("span").textContent
-
-    expect(value1).not.toBe(value2)
-  })
-
-  test("Does not re-render with unchanged values", ()=> {
-    act(()=> { ReactDOM.render(<RenderTest />, container) })
-    const value1 = container.querySelector("span").textContent
-
-    act(()=> {
-      renderStore.update(s=> s.count = s.count)
-      ReactDOM.render(<RenderTest />, container)
-    })
-    const value2 = container.querySelector("span").textContent
-
-    expect(value1).toBe(value2)
-  })
-})
+    expect(value1).toBe(value2);
+  });
+});

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,28 +1,29 @@
-import * as React from 'react'
-import { PureStore } from "./index"
-
+import * as React from "react";
+import { PureStore } from "./index";
 
 class PureStoreReact<S, T> extends PureStore<S, T> {
-  usePureStore                      (): readonly [T, (updater: Partial<T> | ((e: T) => void)) => void]
-  usePureStore <X>(getter?: (s: T)=>X): readonly [X, (updater: Partial<X> | ((e: X) => void)) => void]
+  usePureStore(): readonly [
+    T,
+    (updater: Partial<T> | ((e: T) => void)) => void,
+  ];
+  usePureStore<X>(
+    getter?: (s: T) => X,
+  ): readonly [X, (updater: Partial<X> | ((e: X) => void)) => void];
   usePureStore(getter?) {
     if (getter) {
-      return new PureStoreReact(this, getter).usePureStore()
+      return new PureStoreReact(this, getter).usePureStore();
     }
 
-    const [_, setState] = React.useState(this.getState())
+    const [_, setState] = React.useState(this.getState());
 
-    React.useEffect(()=> {
-      return this.subscribe(()=> setState(this.getState()))
-    }, [])
+    React.useEffect(() => {
+      return this.subscribe(() => setState(this.getState()));
+    }, []);
 
-    return [this.getState(), this.update] as const
+    return [this.getState(), this.update] as const;
   }
 }
 
+export default <S>(state: S) => new PureStoreReact(null, (s: S) => s, state);
 
-export default <S>(state: S)=> (
-  new PureStoreReact(null, (s: S)=> s, state)
-)
-
-export { PureStoreReact as PureStore }
+export { PureStoreReact as PureStore };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,10 +1560,10 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-"immer@1.8.0 - 10":
-  version "9.0.14"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.14.tgz#e05b83b63999d26382bb71676c9d827831248a48"
-  integrity sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==
+immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
 
 import-local@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Updated immer version to latest and fixed issues with the imports. Was using ES5 syntax before and the new immer version would break since the default import wasn't the `produce` function.

Just named the imports and tests passed.

P.S. I hate that I have to make this PR, I want to remove using this as a dependency but when I did and decided to fix all the issues that came from it, the PR was like 300 files and not worth the time to do it all at once.